### PR TITLE
feat: 채팅 메시지 형식 개선 및 캐릭터 위 사용자명 표시

### DIFF
--- a/src/client/controller/NetworkHandler.java
+++ b/src/client/controller/NetworkHandler.java
@@ -36,6 +36,13 @@ public class NetworkHandler implements Runnable {
                     // Manually parse WELCOME message to get player ID
                     String id = serverMessage.split("\"id\":\"")[1].split("\"}")[0];
                     gamePanel.setMyPlayerId(id);
+
+                    // Send username to server
+                    String username = gamePanel.getUsername();
+                    if (username != null) {
+                        String userInfoMsg = String.format("{\"type\":\"USER_INFO\",\"payload\":{\"username\":\"%s\"}}", username);
+                        sendMessage(userInfoMsg);
+                    }
                 } else if (serverMessage.contains("\"type\":\"GAME_STATE\"")) {
                     gamePanel.updateGameState(serverMessage);
                     gamePanel.repaint();

--- a/src/client/util/GameStateParser.java
+++ b/src/client/util/GameStateParser.java
@@ -78,6 +78,10 @@ public class GameStateParser {
 
         for (String playerStr : playersJson.split("\\},\\{")) {
             String id = playerStr.split("\"id\":\"")[1].split("\"")[0];
+            String username = id; // default to id
+            if (playerStr.contains("\"username\":\"")) {
+                username = playerStr.split("\"username\":\"")[1].split("\"")[0];
+            }
             int x = Integer.parseInt(playerStr.split("\"x\":")[1].split(",")[0]);
             int y = Integer.parseInt(playerStr.split("\"y\":")[1].split(",")[0]);
             String directionStr = "right"; // default
@@ -99,6 +103,7 @@ public class GameStateParser {
                 players.add(player);
             }
 
+            player.setUsername(username);
             player.setX(x);
             player.setY(y);
             player.setMapId(mapId);

--- a/src/client/view/GamePanel.java
+++ b/src/client/view/GamePanel.java
@@ -152,6 +152,10 @@ public class GamePanel extends JPanel implements KeyListener, PlayerInputHandler
         this.myPlayerId = id;
     }
 
+    public String getUsername() {
+        return currentUser != null ? currentUser.getUsername() : null;
+    }
+
     public void updateGameState(String jsonState) {
         GameStateParser.parseAndUpdate(jsonState, players, monsters, skills, portals, myPlayerId);
         String newBgPath = GameStateParser.parseBackgroundImagePath(jsonState);

--- a/src/client/view/GameRenderer.java
+++ b/src/client/view/GameRenderer.java
@@ -117,7 +117,11 @@ public class GameRenderer {
                 g.setColor(Color.GREEN);
                 g.drawRect(player.getX() - 2, player.getY() - 2, 104, 104);
             }
-            g.drawString(player.getId(), player.getX(), player.getY() - 5);
+
+            // Display username above player
+            String displayName = player.getUsername() != null ? player.getUsername() : player.getId();
+            g.setColor(Color.WHITE);
+            g.drawString(displayName, player.getX() + 25, player.getY() - 5);
         }
     }
 }

--- a/src/common/player/Player.java
+++ b/src/common/player/Player.java
@@ -4,6 +4,7 @@ import common.enums.Direction;
 
 public class Player {
     private String id;
+    private String username;
     private int x;
     private int y;
     private String state; // "idle", "move", "jump"
@@ -24,6 +25,14 @@ public class Player {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public int getX() {

--- a/src/server/handler/ClientHandler.java
+++ b/src/server/handler/ClientHandler.java
@@ -50,7 +50,9 @@ public class ClientHandler implements Runnable {
 
             String inputLine;
             while ((inputLine = in.readLine()) != null) {
-                if (inputLine.contains("\"type\":\"PLAYER_UPDATE\"")) {
+                if (inputLine.contains("\"type\":\"USER_INFO\"")) {
+                    handleUserInfo(inputLine);
+                } else if (inputLine.contains("\"type\":\"PLAYER_UPDATE\"")) {
                     handlePlayerUpdate(inputLine);
                 } else if (inputLine.contains("\"type\":\"SKILL_USE\"")) {
                     handleSkillUse(inputLine);
@@ -133,11 +135,28 @@ public class ClientHandler implements Runnable {
         }
     }
 
+    private void handleUserInfo(String message) {
+        try {
+            String username = message.split("\"username\":\"")[1].split("\"")[0];
+            Player player = gameState.getPlayer(playerId);
+            if (player != null) {
+                player.setUsername(username);
+                System.out.println("Player " + playerId + " set username: " + username);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to handle user info: " + message);
+        }
+    }
+
     private void handleChat(String message) {
         try {
             String content = message.split("\"message\":\"")[1].split("\"")[0];
             String time = java.time.LocalTime.now().format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"));
-            String formattedMessage = String.format("[%s] %s", time, content);
+
+            Player player = gameState.getPlayer(playerId);
+            String username = player != null && player.getUsername() != null ? player.getUsername() : playerId;
+
+            String formattedMessage = String.format("[%s]%s:%s", time, username, content);
 
             String broadcastJson = String.format("{\"type\":\"CHAT\",\"payload\":{\"message\":\"%s\"}}",
                     formattedMessage);

--- a/src/server/util/GameStateSerializer.java
+++ b/src/server/util/GameStateSerializer.java
@@ -62,8 +62,9 @@ public class GameStateSerializer {
         sb.append(",\"players\":[");
         for (Player p : players) {
             String directionStr = p.getDirection() != null ? p.getDirection().getValue() : "right";
-            sb.append(String.format("{\"id\":\"%s\",\"x\":%d,\"y\":%d,\"direction\":\"%s\",\"mapId\":\"%s\"}",
-                    p.getId(), p.getX(), p.getY(), directionStr, p.getMapId()));
+            String username = p.getUsername() != null ? p.getUsername() : p.getId();
+            sb.append(String.format("{\"id\":\"%s\",\"username\":\"%s\",\"x\":%d,\"y\":%d,\"direction\":\"%s\",\"mapId\":\"%s\"}",
+                    p.getId(), username, p.getX(), p.getY(), directionStr, p.getMapId()));
             sb.append(",");
         }
         if (!players.isEmpty()) {


### PR DESCRIPTION
채팅 메시지를 [시간]닉네임:메시지 형식으로 변경하고,
캐릭터 위에 플레이어 ID 대신 사용자명(아이디)을 표시하도록 개선.

- Player 모델에 username 필드 추가
- 클라이언트-서버 간 USER_INFO 메시지 타입 추가
  - 로그인 후 클라이언트가 username을 서버로 전송
  - 서버가 Player 객체에 username 저장

- 채팅 시스템 개선:
  - 기존: [시간] 메시지
  - 변경: [시간]닉네임:메시지

- 렌더링 개선:
  - 캐릭터 위에 player_xxxxx 대신 사용자명 표시
  - username이 없으면 fallback으로 ID 사용

- GameStateSerializer/Parser에 username 직렬화/역직렬화 추가